### PR TITLE
Add launchSettings to force enabling Development mode during development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 examples/
 **/*.pem
 level*.bin
-**/Properties/launchSettings.json
 **/BenchmarkDotNet.Artifacts/
 coveragereport/
 Test/TestResults/

--- a/Portal/Properties/launchSettings.json
+++ b/Portal/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5001",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:5101;http://localhost:5001",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Without launchSettings, it starts the app in Production mode (at least in VSCode), which causes a 404 on `Portal.styles.css`.
Apparently, launchSettings should (no longer) be gitignored.

See also e.g. https://github.com/github/VisualStudio/issues/1405