### PR TITLE
Rework sessions events

### DIFF
--- a/Server/IGameServer.cs
+++ b/Server/IGameServer.cs
@@ -3,19 +3,13 @@ using System.Collections.Immutable;
 
 namespace Swoq.Server;
 
-public record GameAddedEventArgs(Guid GameId, string UserName, int Level, bool IsQuest);
 public record GameRemovedEventArgs(Guid GameId);
-public record GameUpdatedEventArgs(Guid GameId, int Level, bool IsFinished);
 public record QueueUpdatedEventArgs(IImmutableList<string> QueuedUsers);
-public record StatisticsUpdatedEventArgs(float EventsPerSecond);
 
 public interface IGameServer
 {
-    event EventHandler<GameAddedEventArgs>? GameAdded;
     event EventHandler<GameRemovedEventArgs>? GameRemoved;
-    event EventHandler<GameUpdatedEventArgs>? GameUpdated;
     event EventHandler<QueueUpdatedEventArgs>? QueueUpdated;
-    event EventHandler<StatisticsUpdatedEventArgs>? StatisticsUpdated;
 
     GameStartResult Start(string userId, int? level);
     GameState Act(Guid gameId, DirectedAction? action1 = null, DirectedAction? action2 = null);

--- a/Server/Parameters.cs
+++ b/Server/Parameters.cs
@@ -15,9 +15,9 @@ internal static class Parameters
 
     public const int ExtraHealth = 3;
 
-    public static readonly TimeSpan GameRetentionTime = TimeSpan.FromMinutes(1);
+    public static readonly TimeSpan GameRetentionTime = TimeSpan.FromSeconds(30);
 
-    public static readonly TimeSpan MaxTrainingInactivityTime = TimeSpan.FromSeconds(30);
+    public static readonly TimeSpan MaxTrainingInactivityTime = TimeSpan.FromSeconds(10);
 
     public static readonly TimeSpan MaxQuestInactivityTime = TimeSpan.FromSeconds(10);
 

--- a/Server/ReplaySaver.cs
+++ b/Server/ReplaySaver.cs
@@ -66,7 +66,7 @@ internal class ReplaySaver : IDisposable
             filenames = filenames.Add(e.gameId, filename);
         }
 
-        logger.LogInformation("New replay started at {path}", filename);
+        //logger.LogInformation("New replay started at {path}", filename);
 
         var header = new ReplayHeader { UserName = e.userName, DateTime = Clock.Now.ToString("s") };
         Enqueue(e.gameId, header);


### PR DESCRIPTION
The game added and updated events can be replaced by the postman events that were already handled. The statistics are moved to the DashboardService, so GameServer becomes simpler.

Also the locking in GameServer is changed. Only the start of a quest is locked. The rest of the locks are replaced by using Concurrent collections.

For extra information an inner exception is added to the GameServerException, so when internal errors happen the original cause is logged.

Fixes #3 