### PR TITLE
Prevent Use actions in first levels

### DIFF
--- a/Infra/Map.cs
+++ b/Infra/Map.cs
@@ -1,5 +1,6 @@
 ﻿namespace Swoq.Infra;
 
+using System.Collections;
 using System.Collections.Immutable;
 
 public class Map(
@@ -12,7 +13,7 @@ public class Map(
     Player? player2,
     Enemy? enemy1,
     Enemy? enemy2,
-    Enemy? enemy3)
+    Enemy? enemy3) : IEnumerable<Cell>
 {
     public static readonly Map Empty = new(-1, 0, 0, [], false, null, null, null, null, null);
 
@@ -110,4 +111,8 @@ public class Map(
             if (Enemy3 != null) yield return Enemy3;
         }
     }
+
+    public IEnumerator<Cell> GetEnumerator() => cells.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)cells).GetEnumerator();
 }

--- a/Server/Game.cs
+++ b/Server/Game.cs
@@ -27,6 +27,8 @@ internal class Game : IGame
     private readonly HashSet<Position> doorsToClose = [];
     private readonly HashSet<Position> doorsToOpen = [];
 
+    private readonly bool mapHasUsableItems;
+
     public Game(
         Map map,
         TimeSpan maxInactivityTime,
@@ -45,6 +47,8 @@ internal class Game : IGame
         startTime = Clock.Now;
 
         State = CreateState();
+
+        mapHasUsableItems = map.Enemies.Any() || map.Any(c => c is Cell.Boulder or Cell.DoorRedClosed or Cell.DoorGreenClosed or Cell.DoorBlueClosed);
     }
 
     public Guid Id { get; } = Guid.NewGuid();
@@ -223,6 +227,7 @@ internal class Game : IGame
             case DirectedAction.UseEast:
             case DirectedAction.UseSouth:
             case DirectedAction.UseWest:
+                if (!mapHasUsableItems) throw new UnknownActionException();
                 Use(ref player, actionPos);
                 break;
             default:

--- a/Test/GameTestBase.cs
+++ b/Test/GameTestBase.cs
@@ -19,6 +19,11 @@ internal abstract class GameTestBase
         var random = new Random(1337);
 
         var map = CreateGameMap();
+        Reset(random, map);
+    }
+
+    protected void Reset(Random random, Map map)
+    {
         game = new Game(map, TimeSpan.FromSeconds(20), 2000, TimeSpan.FromSeconds(300), random);
         mapCache = new MapCache(map.Height, map.Width, 8); // TODO: Get visiblity range
         mapCache.AddPlayerStates(game.State.Player1, game.State.Player2);

--- a/Test/UseTests.cs
+++ b/Test/UseTests.cs
@@ -354,7 +354,28 @@ internal class UseTests : GameTestBase
         Assert.Throws<UseNotAllowedException>(() => Act(action2: DirectedAction.UseWest));
     }
 
-    protected override Map CreateGameMap()
+    [Test]
+    public void UseOnSimpleMapsNotAllowed()
+    {
+        var map = CreateMap(true);
+        Reset(Random.Shared, map);
+
+        // Standard actions are allowed
+        Act(DirectedAction.None);
+        Act(DirectedAction.MoveNorth);
+        Act(DirectedAction.MoveEast);
+        Act(DirectedAction.MoveSouth);
+        Act(DirectedAction.MoveWest);
+        // Use is not allowed
+        Assert.Throws<UnknownActionException>(() => Act(DirectedAction.UseNorth));
+        Assert.Throws<UnknownActionException>(() => Act(DirectedAction.UseEast));
+        Assert.Throws<UnknownActionException>(() => Act(DirectedAction.UseSouth));
+        Assert.Throws<UnknownActionException>(() => Act(DirectedAction.UseWest));
+    }
+
+    protected override Map CreateGameMap() => CreateMap(false);
+
+    private static Map CreateMap(bool simple )
     {
         var width = 11;
         var height = 13;
@@ -380,30 +401,34 @@ internal class UseTests : GameTestBase
 
         // Two players in center
         map.Player1.Position = map.Pos((height - 1) / 2, (width - 1) / 2);
-        map.Player2.Position = map.Pos((height - 1) / 2, (width - 1) / 2 + 1);
 
-        // Swords near players
-        map[map.Player1.Position.y + 1, map.Player1.Position.x] = Cell.Sword;
-        map[map.Player2.Position.y - 1, map.Player2.Position.x] = Cell.Sword;
+        if (!simple)
+        {
+            map.Player2.Position = map.Pos((height - 1) / 2, (width - 1) / 2 + 1);
 
-        // One enemy in top (in wall)
-        map.Enemy1.Position = map.Pos(0, (width - 1) / 2);
-        map[map.Enemy1.Position] = Cell.Empty;
+            // Swords near players
+            map[map.Player1.Position.y + 1, map.Player1.Position.x] = Cell.Sword;
+            map[map.Player2.Position.y - 1, map.Player2.Position.x] = Cell.Sword;
 
-        // Boulder in left
-        map[map.Player1.Position.y, 1] = Cell.Boulder;
+            // One enemy in top (in wall)
+            map.Enemy1.Position = map.Pos(0, (width - 1) / 2);
+            map[map.Enemy1.Position] = Cell.Empty;
 
-        // A key near player 2
-        map[map.Player2.Position.y + 1, map.Player2.Position.x] = Cell.KeyRed;
+            // Boulder in left
+            map[map.Player1.Position.y, 1] = Cell.Boulder;
 
-        // A door on the right
-        map[map.Player2.Position.y, width - 2] = Cell.DoorRedClosed;
+            // A key near player 2
+            map[map.Player2.Position.y + 1, map.Player2.Position.x] = Cell.KeyRed;
+
+            // A door on the right
+            map[map.Player2.Position.y, width - 2] = Cell.DoorRedClosed;
+
+            // Health below player 2
+            map[height - 2, map.Player2.Position.x] = Cell.Health;
+        }
 
         // Exit bottom right
         map[height - 2, width - 2] = Cell.Exit;
-
-        // Health below player 2
-        map[height - 2, map.Player2.Position.x] = Cell.Health;
 
         return map.ToMap();
     }


### PR DESCRIPTION
Up till level 2 the proto file does not mention the Use actions. These are the only levels that do not contain anything to use on (enemies, boulders or closed doors), so a simple check is added at the start of the game whether or not use is allowed. A test is added to cover this situation.

Fixes #72