### PR TITLE
Add level number to seed

### DIFF
--- a/MapGeneratorTester/MainViewModel.cs
+++ b/MapGeneratorTester/MainViewModel.cs
@@ -10,7 +10,7 @@ internal class MainViewModel : ViewModelBase, IDisposable
 
     public MainViewModel()
     {
-        var random = new Random(seed ?? Random.Shared.Next());
+        var random = new Random((seed ?? Random.Shared.Next()) + Level);
         Overview.TileMap = mapGenerator.Generate(Level, Height, Width, random).ToOverview();
         Generate = new RelayCommand(HandleGenerate);
     }
@@ -105,7 +105,7 @@ internal class MainViewModel : ViewModelBase, IDisposable
         Status = "Generating ...";
         try
         {
-            var random = new Random(seed ?? Random.Shared.Next());
+            var random = new Random((seed ?? Random.Shared.Next()) + Level);
             Overview.TileMap = mapGenerator.Generate(Level, Height, Width, random).ToOverview();
             Status = "";
         }

--- a/Server/GameServer.cs
+++ b/Server/GameServer.cs
@@ -1,4 +1,4 @@
-﻿using Swoq.Data;
+using Swoq.Data;
 using Swoq.Infra;
 using Swoq.Interface;
 using System.Collections.Concurrent;
@@ -141,7 +141,7 @@ internal class GameServer(IMapGenerator mapGenerator, ISwoqDatabase database, in
         // Check if user can play this level
         if (level < 0 || level > user.Level || level > mapGenerator.MaxLevel) throw new InvalidLevelException();
 
-        var random = new Random(seed);
+        var random = new Random(seed + level);
         var map = mapGenerator.Generate(level, Parameters.MapHeight, Parameters.MapWidth, random);
         var reporter = new UserStatisticsReporter(user, database);
 

--- a/Server/Quest.cs
+++ b/Server/Quest.cs
@@ -1,4 +1,4 @@
-﻿using Swoq.Data;
+using Swoq.Data;
 using Swoq.Infra;
 using Swoq.Interface;
 
@@ -114,7 +114,7 @@ public class Quest : IGame
     private Game NewGame()
     {
         // Use the same seed for every level in this quest
-        var random = new Random(seed);
+        var random = new Random(seed + level);
 
         var map = mapGenerator.Generate(level, Parameters.MapHeight, Parameters.MapWidth, random);
         return new Game(map,


### PR DESCRIPTION
By adding the level number to the seed to get the actual seed, levels with the same build-up get a different layout.

Fixes #88 