### PR TITLE
Properly show canceled quests

### DIFF
--- a/Dashboard/Views/MainWindow.xaml
+++ b/Dashboard/Views/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window xmlns="https://github.com/avaloniaui"
+<Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -24,52 +24,11 @@
                 <ColumnDefinition Width="{Binding Maximize, Converter={StaticResource gridConverter}, ConverterParameter=200}"/>
                 <ColumnDefinition Width="{Binding Maximize, Converter={StaticResource gridConverter}, ConverterParameter=200}"/>
                 <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="{Binding Maximize, Converter={StaticResource gridConverter}, ConverterParameter=320}"/>
             </Grid.ColumnDefinitions>
 
-            <infraui:GroupBox Grid.Column="0" Header="Sessions"  DataContext="{Binding GameObserver}">
-                <ScrollViewer>
-                    <ItemsControl ItemsSource="{Binding Sessions}">
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <Grid RowDefinitions="auto,auto" ColumnDefinitions="3*,1*">
-                                    <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal">
-                                        <TextBlock  Foreground="{Binding TextColor}" Text="{Binding UserName}"/>
-                                        <TextBlock  Foreground="{Binding TextColor}" IsVisible="{Binding IsFinished}">✓</TextBlock>
-                                    </StackPanel>
-                                    <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding Level}" TextAlignment="Right" Foreground="{Binding TextColor}"/>
-                                </Grid>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
-                </ScrollViewer>
-            </infraui:GroupBox>
-
-            <Grid Grid.Column="1" RowDefinitions="*,auto,auto"  DataContext="{Binding GameObserver}">
-                <infraui:GroupBox Grid.Row="0" Header="Highscores">
-                    <ScrollViewer>
-                        <ItemsControl ItemsSource="{Binding Scores}">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <Grid RowDefinitions="auto,auto" ColumnDefinitions="3*,1*">
-                                        <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal">
-                                            <TextBlock Text="{Binding UserName}"/>
-                                            <TextBlock IsVisible="{Binding QuestFinished}">🌟</TextBlock>
-                                        </StackPanel>
-                                        <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding Level}" TextAlignment="Right"/>
-                                        <TextBlock Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" TextAlignment="Right" FontSize="12" IsVisible="{Binding HasProgress}">
-                                            <Run Text="{Binding LengthTicks}"/>
-                                            <Run>ticks,</Run>
-                                            <Run Text="{Binding LengthSeconds}"/>
-                                            <Run>sec.</Run>
-                                        </TextBlock>
-                                    </Grid>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
-                    </ScrollViewer>
-                </infraui:GroupBox>
-
-                <infraui:GroupBox Grid.Row="1" Header="Queue">
+            <Grid Grid.Column="0" RowDefinitions="auto,*"  DataContext="{Binding GameObserver}">
+                <infraui:GroupBox Grid.Row="0" Header="Queue">
                     <ItemsControl ItemsSource="{Binding QueueUsers}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
@@ -78,10 +37,52 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </infraui:GroupBox>
+
+                <infraui:GroupBox Grid.Row="1" Header="Sessions">
+                    <ScrollViewer>
+                        <ItemsControl ItemsSource="{Binding Sessions}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid RowDefinitions="auto,auto" ColumnDefinitions="3*,1*">
+                                        <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal">
+                                            <TextBlock  Foreground="{Binding TextColor}" Text="{Binding UserName}"/>
+                                            <TextBlock  Foreground="{Binding TextColor}" IsVisible="{Binding IsFinished}">✓</TextBlock>
+                                        </StackPanel>
+                                        <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding Level}" TextAlignment="Right" Foreground="{Binding TextColor}"/>
+                                    </Grid>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
+                </infraui:GroupBox>
             </Grid>
 
+            <infraui:GroupBox Grid.Column="1" Header="Highscores" DataContext="{Binding GameObserver}">
+                <ScrollViewer>
+                    <ItemsControl ItemsSource="{Binding Scores}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Grid RowDefinitions="auto,auto" ColumnDefinitions="3*,1*">
+                                    <StackPanel Grid.Row="0" Grid.Column="0" Orientation="Horizontal">
+                                        <TextBlock Text="{Binding UserName}"/>
+                                        <TextBlock IsVisible="{Binding QuestFinished}">🌟</TextBlock>
+                                    </StackPanel>
+                                    <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding Level}" TextAlignment="Right"/>
+                                    <TextBlock Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" TextAlignment="Right" FontSize="12" IsVisible="{Binding HasProgress}">
+                                        <Run Text="{Binding LengthTicks}"/>
+                                        <Run>ticks,</Run>
+                                        <Run Text="{Binding LengthSeconds}"/>
+                                        <Run>sec.</Run>
+                                    </TextBlock>
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+            </infraui:GroupBox>
+
             <Grid Grid.Column="2" DataContext="{Binding GameObserver}">
-                <ItemsControl ItemsSource="{Binding GameObservations}">
+                <ItemsControl ItemsSource="{Binding ActiveQuests}">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate>
                             <UniformGrid Columns="{Binding Columns}" />
@@ -93,12 +94,34 @@
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
-                <!---->
                 <Canvas>
                     <Button Canvas.Top="0" Canvas.Right="0" Click="OnMaximizeClicked">
                         <Image Source="maximize.png" Width="32" Height="32"/>
                     </Button>
                 </Canvas>
+            </Grid>
+
+            <Grid Grid.Column="3" DataContext="{Binding GameObserver}">
+                <infraui:GroupBox Grid.Row="0" Header="Previous quests">
+                    <ScrollViewer>
+                        <ItemsControl ItemsSource="{Binding InactiveQuests}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <StackPanel Orientation="Vertical" />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate DataType="infravm:GameObservationViewModel">
+                                    <Viewbox Width="320" Height="240">
+                                        <Border Width="480" Height="360" Margin="4">
+                                            <infraui:GameObservationView DataContext="{Binding}" ShowHeader="true" ShowSidePanels="false" />
+                                        </Border>
+                                    </Viewbox>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
+                </infraui:GroupBox>
             </Grid>
         </Grid>
 

--- a/InfraUI/Models/GameObservationBuilder.cs
+++ b/InfraUI/Models/GameObservationBuilder.cs
@@ -1,7 +1,8 @@
-﻿using Avalonia.Threading;
+using Avalonia.Threading;
 using Swoq.Infra;
 using Swoq.Interface;
 using System.Collections.Immutable;
+using System.Diagnostics;
 
 namespace Swoq.InfraUI.Models;
 
@@ -90,6 +91,25 @@ public class GameObservationBuilder(string id, int height, int width, int visibi
             overview,
             player1State,
             player2State));
+        previous = gameState;
+        return gameState;
+    }
+
+    public GameObservation SetGameStatus(GameStatus gameStatus, Dispatcher createDispatcher)
+    {
+        Debug.Assert(previous != null);
+        var gameState = createDispatcher.Invoke(() => new GameObservation(
+            userName,
+            previous.Level != initialLevel,
+            previous.Tick,
+            previous.Level,
+            gameStatus,
+            previous.ActionResult,
+            previous.HasEnemies,
+            previous.HasSwordPickup,
+            previous.Overview,
+            previous.Player1,
+            previous.Player2));
         previous = gameState;
         return gameState;
     }

--- a/InfraUI/ViewModels/GameObservationViewModel.cs
+++ b/InfraUI/ViewModels/GameObservationViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Swoq.Infra;
+using Swoq.Infra;
 using Swoq.InfraUI.Models;
 using Swoq.Interface;
 
@@ -60,6 +60,7 @@ public class GameObservationViewModel(GameObservation? observation = null) : Vie
         GameStatus.FinishedTimeout => "🛑 Timeout 🛑",
         GameStatus.FinishedNoProgress => "🛑 No progress 🛑",
         GameStatus.FinishedPlayerDied => "🛑 Player died 🛑",
+        GameStatus.FinishedCancelled => "🛑 Game canceled 🛑",
         GameStatus.FinishedPlayer2Died => "🛑 Player 2 died 🛑",
         _ => throw new NotImplementedException(),
     };

--- a/InfraUI/Views/GameObservationView.xaml
+++ b/InfraUI/Views/GameObservationView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -22,7 +22,7 @@
             <Image Grid.Row="1" Source="{Binding Overview.Image}" Stretch="Uniform" RenderOptions.BitmapInterpolationMode="None"/>
         </Grid>
 
-        <Grid Grid.Column="1" RowDefinitions="auto,*,*">
+        <Grid Grid.Column="1" RowDefinitions="auto,*,*" IsVisible="{Binding #self.ShowSidePanels}">
             <local:GroupBox Grid.Row="0" Header="Game">
                 <StackPanel Orientation="Vertical">
                     <TextBlock>
@@ -44,7 +44,7 @@
         </Grid>
 
         <Grid Grid.Column="0" ColumnDefinitions="*,auto,*" RowDefinitions="*,auto,auto,*" IsVisible="{Binding IsFinished}">
-            <Panel Grid.Row="0" Grid.RowSpan="4" Grid.Column="0" Grid.ColumnSpan="3" Opacity="0.75" Background="Black" />
+            <Panel Grid.Row="0" Grid.RowSpan="4" Grid.Column="0" Grid.ColumnSpan="3" Opacity="0.50" Background="Black" />
             <TextBlock Grid.Row="1" Grid.Column="1" FontSize="18" HorizontalAlignment="Center" Text="Game finished"/>
             <TextBlock Grid.Row="2" Grid.Column="1" FontSize="24" FontWeight="Bold" HorizontalAlignment="Center" Text="{Binding FinishedResult}"/>
         </Grid>

--- a/InfraUI/Views/GameObservationView.xaml.cs
+++ b/InfraUI/Views/GameObservationView.xaml.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia;
+using Avalonia;
 using Avalonia.Controls;
 
 namespace Swoq.InfraUI.Views;
@@ -12,5 +12,14 @@ public partial class GameObservationView : UserControl
     {
         get { return GetValue(ShowHeaderProperty); }
         set { SetValue(ShowHeaderProperty, value); }
+    }
+
+    public static readonly StyledProperty<bool> ShowSidePanelsProperty =
+        AvaloniaProperty.Register<GroupBox, bool>(nameof(ShowSidePanels), defaultValue: true);
+
+    public bool ShowSidePanels
+    {
+        get { return GetValue(ShowSidePanelsProperty); }
+        set { SetValue(ShowSidePanelsProperty, value); }
     }
 }

--- a/InfraUI/Views/GroupBox.xaml
+++ b/InfraUI/Views/GroupBox.xaml
@@ -7,7 +7,7 @@
             <Grid RowDefinitions="auto,*" ColumnDefinitions="auto,*" Margin="8">
 
                 <Border Grid.Row="0" Grid.Column="0" Grid.RowSpan="2" Grid.ColumnSpan="2"
-                        Margin="0,8,0,0"
+                        Margin="0,10,0,0"
                         Padding="10"
                         CornerRadius="5"
                         BorderThickness="2" BorderBrush="{DynamicResource SliderTrackFill}"

--- a/Interface/dashboard.proto
+++ b/Interface/dashboard.proto
@@ -54,6 +54,11 @@ message StatisticsUpdate {
     float eventsPerSecond = 1;
 }
 
+message QuestStatusChanged {
+    string gameId = 1;
+    GameStatus status = 2;
+}
+
 message Update {
     optional QuestStarted questStarted = 1;
     optional QuestActed questActed = 2;
@@ -61,4 +66,5 @@ message Update {
     optional SessionsUpdate sessionsUpdate = 4;
     optional ScoresUpdate scoresUpdate = 5;
     optional StatisticsUpdate statisticsUpdate = 6;
+    optional QuestStatusChanged questStatusChanged = 7;
 }

--- a/Server/GameServer.cs
+++ b/Server/GameServer.cs
@@ -12,10 +12,12 @@ internal class GameServer : GameServerBase, IDisposable
     {
         queueManager = new(mapGenerator, database, maxNrActiveQuests, queueWaitTime);
         queueManager.QueueUpdated += OnQueueManagerQueueUpdated;
+        queueManager.GameStatusChanged += OnQueueManagerGameStatusChanged;
     }
 
     public void Dispose()
     {
+        queueManager.GameStatusChanged -= OnQueueManagerGameStatusChanged;
         queueManager.QueueUpdated -= OnQueueManagerQueueUpdated;
         queueManager.Dispose();
     }
@@ -54,4 +56,5 @@ internal class GameServer : GameServerBase, IDisposable
     }
 
     private void OnQueueManagerQueueUpdated(object? sender, QueueUpdatedEventArgs args) => OnQueueUpdated(args.QueuedUsers);
+    private void OnQueueManagerGameStatusChanged(object? sender, GameStatusChangedEventArgs args) => OnGameStatusChanged(args.GameId, args.Status);
 }

--- a/Server/GameServerBase.cs
+++ b/Server/GameServerBase.cs
@@ -25,8 +25,8 @@ internal abstract class GameServerBase(IMapGenerator mapGenerator, ISwoqDatabase
     protected readonly ConcurrentDictionary<Guid, IGame> games = new();
 
     public event EventHandler<GameRemovedEventArgs>? GameRemoved;
-
     public event EventHandler<QueueUpdatedEventArgs>? QueueUpdated;
+    public event EventHandler<GameStatusChangedEventArgs>? GameStatusChanged;
 
     public GameStartResult Start(string userId, string userName, int? level, int? seed = null)
     {
@@ -127,12 +127,13 @@ internal abstract class GameServerBase(IMapGenerator mapGenerator, ISwoqDatabase
     {
         if (games.TryRemove(gameId, out var game))
         {
-            GameRemoved?.Invoke(this, new GameRemovedEventArgs(gameId));
+            OnGameRemoved(gameId);
         }
     }
 
-    protected void OnQueueUpdated(IImmutableList<string> queuedUsers)
-    {
-        QueueUpdated?.Invoke(this, new QueueUpdatedEventArgs(queuedUsers));
-    }
+    protected void OnGameRemoved(Guid gameId) => GameRemoved?.Invoke(this, new GameRemovedEventArgs(gameId));
+
+    protected void OnQueueUpdated(IImmutableList<string> queuedUsers) => QueueUpdated?.Invoke(this, new QueueUpdatedEventArgs(queuedUsers));
+
+    protected void OnGameStatusChanged(Guid gameId, GameStatus status) => GameStatusChanged?.Invoke(this, new GameStatusChangedEventArgs(gameId, status));
 }

--- a/Server/IGameServer.cs
+++ b/Server/IGameServer.cs
@@ -1,4 +1,4 @@
-﻿using Swoq.Interface;
+using Swoq.Interface;
 using System.Collections.Immutable;
 
 namespace Swoq.Server;
@@ -13,10 +13,17 @@ public class QueueUpdatedEventArgs(IImmutableList<string> queuedUsers) : EventAr
     public IImmutableList<string> QueuedUsers { get; } = queuedUsers;
 }
 
+public class GameStatusChangedEventArgs(Guid gameId, GameStatus status) : EventArgs
+{
+    public Guid GameId { get; } = gameId;
+    public GameStatus Status { get; } = status;
+}
+
 public interface IGameServer
 {
     event EventHandler<GameRemovedEventArgs>? GameRemoved;
     event EventHandler<QueueUpdatedEventArgs>? QueueUpdated;
+    event EventHandler<GameStatusChangedEventArgs>? GameStatusChanged;
 
     GameStartResult Start(string userId, string userName, int? level, int? seed = null);
     GameState Act(Guid gameId, DirectedAction? action1 = null, DirectedAction? action2 = null);


### PR DESCRIPTION
When a quest is canceled the new game status is not sent to the dashboard, because no further interaction takes place at the GameService level. The dashboard does not get a new ActRequest/Response update, so it does not know the new game status. A new update event is added to the dashboard service to notify status changes. The game observation is adjusted accordingly. It is now only triggered when the a game is canceled, but should also be triggeren when a game times out. Will fix that at a later time.

Fixes #84.