### PR TITLE
Make player surroundings fixed size and show seed in replay

### DIFF
--- a/Dashboard/ViewModels/GameObserverViewModel.cs
+++ b/Dashboard/ViewModels/GameObserverViewModel.cs
@@ -180,7 +180,7 @@ internal class GameObserverViewModel : ViewModelBase, IDisposable
 
     private void HandleQuestStarted(QuestStarted update)
     {
-        var builder = new GameObservationBuilder(update.GameId, update.Response.MapHeight, update.Response.MapWidth, update.Response.VisibilityRange, update.Request.UserName);
+        var builder = new GameObservationBuilder(update.GameId, update.Response.Seed, update.Response.MapHeight, update.Response.MapWidth, update.Response.VisibilityRange, update.Request.UserName);
         var gameState = builder.BuildNext(null, update.Response.State, update.Response.Result, Dispatcher.UIThread);
 
         GameObservationViewModel viewModel = Dispatcher.UIThread.Invoke(() =>

--- a/Dashboard/Views/MainWindow.xaml
+++ b/Dashboard/Views/MainWindow.xaml
@@ -71,7 +71,7 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate DataType="infravm:GameObservationViewModel">
                                 <Viewbox>
-                                    <Border Width="1920" Height="1060" Margin="4">
+                                    <Border Width="1920" Height="1060">
                                         <!-- leave some room for status bar -->
                                         <infraui:GameObservationView DataContext="{Binding}" ShowHeader="true"/>
                                     </Border>

--- a/InfraUI/Models/GameObservation.cs
+++ b/InfraUI/Models/GameObservation.cs
@@ -1,4 +1,4 @@
-﻿using Swoq.Infra;
+using Swoq.Infra;
 using Swoq.Interface;
 
 namespace Swoq.InfraUI.Models;
@@ -13,6 +13,7 @@ public record PlayerObservation(
 public record GameObservation(
     string UserName,
     bool IsQuest,
+    int Seed,
     int Tick,
     int Level,
     GameStatus Status,

--- a/InfraUI/ViewModels/GameObservationViewModel.cs
+++ b/InfraUI/ViewModels/GameObservationViewModel.cs
@@ -18,6 +18,7 @@ public class GameObservationViewModel(GameObservation? observation = null) : Vie
             OnPropertyChanged(nameof(IsLoaded));
 
             OnPropertyChanged(nameof(UserName));
+            OnPropertyChanged(nameof(Seed));
             OnPropertyChanged(nameof(Tick));
             OnPropertyChanged(nameof(Level));
             OnPropertyChanged(nameof(ActionResult));
@@ -48,6 +49,7 @@ public class GameObservationViewModel(GameObservation? observation = null) : Vie
     public bool IsLoaded => Current != null;
 
     public string UserName => Current?.UserName ?? "Unknown";
+    public int Seed => Current?.Seed ?? -1;
     public int Tick => Current?.Tick ?? -1;
     public int Level => Current?.Level ?? -1;
     public string ActionResult => Current?.ActionResult ?? "Unknown";

--- a/InfraUI/Views/GameObservationView.xaml
+++ b/InfraUI/Views/GameObservationView.xaml
@@ -11,25 +11,29 @@
              Foreground="White"
              Name="self">
     <Grid Grid.RowDefinitions="auto,*" ColumnDefinitions="*,auto" IsVisible="{Binding IsLoaded}">
-        <TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" FontSize="24" HorizontalAlignment="Center" IsVisible="{Binding #self.ShowHeader}">
+        <SelectableTextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" FontSize="24" HorizontalAlignment="Center" IsVisible="{Binding #self.ShowHeader}">
             <Run Text="{Binding UserName, Mode=OneWay}" />
             <Run> - Level </Run>
             <Run Text="{Binding Level, Mode=OneWay}" />
-        </TextBlock>
+        </SelectableTextBlock>
 
         <Image Grid.Row="1" Grid.Column="0" Source="{Binding Overview.Image}" Stretch="Uniform" RenderOptions.BitmapInterpolationMode="None"/>
 
         <Grid Grid.Row="1" Grid.Column="1" RowDefinitions="auto,*,*" IsVisible="{Binding #self.ShowSidePanels}">
             <local:GroupBox Grid.Row="0" Header="Game">
                 <StackPanel Orientation="Vertical">
-                    <TextBlock>
+                    <SelectableTextBlock>
+                        <Run>Seed:</Run>
+                        <Run Text="{Binding Seed, Mode=OneWay}" />
+                    </SelectableTextBlock>
+                    <SelectableTextBlock>
                         <Run>Tick:</Run>
                         <Run Text="{Binding Tick, Mode=OneWay}" />
-                    </TextBlock>
-                    <TextBlock>
+                    </SelectableTextBlock>
+                    <SelectableTextBlock>
                         <Run>Result:</Run>
                         <Run Text="{Binding ActionResult, Mode=OneWay}" />
-                    </TextBlock>
+                    </SelectableTextBlock>
                 </StackPanel>
             </local:GroupBox>
 

--- a/ReplayViewer/ViewModels/ReplayViewModel.cs
+++ b/ReplayViewer/ViewModels/ReplayViewModel.cs
@@ -100,7 +100,7 @@ internal class ReplayViewModel : ViewModelBase, IDisposable
             var startRequest = StartRequest.Parser.ParseDelimitedFrom(file);
             var startResponse = StartResponse.Parser.ParseDelimitedFrom(file);
 
-            var builder = new GameObservationBuilder(startResponse.GameId, startResponse.MapHeight, startResponse.MapWidth, startResponse.VisibilityRange, startRequest.UserName);
+            var builder = new GameObservationBuilder(startResponse.GameId, startResponse.Seed, startResponse.MapHeight, startResponse.MapWidth, startResponse.VisibilityRange, startRequest.UserName);
 
             var gameState = builder.BuildNext(null, startResponse.State, startResponse.Result, Dispatcher.UIThread);
             gameStates = gameStates.Add(gameState);

--- a/ReplayViewer/Views/MainWindow.xaml
+++ b/ReplayViewer/Views/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window xmlns="https://github.com/avaloniaui"
+<Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -13,7 +13,7 @@
     <Grid RowDefinitions="auto,*">
         <Grid Grid.Row="0" ColumnDefinitions="auto,*">
             <Button Grid.Column="0" Margin="8" Padding="8" VerticalAlignment="Center" Command="{Binding LoadCommand}">💾 Load</Button>
-            <TextBlock Grid.Column="1" VerticalAlignment="Center" TextAlignment="Left" Text="{Binding CurrentFile}"/>
+            <SelectableTextBlock Grid.Column="1" VerticalAlignment="Center" TextAlignment="Left" Text="{Binding CurrentFile}"/>
         </Grid>
         <local:ReplayView Grid.Row="1" DataContext="{Binding Replay}"/>
 
@@ -22,7 +22,7 @@
                 <StackPanel Grid.Row="1" Grid.Column="1" Orientation="Vertical">
                     <TextBlock FontWeight="Bold" HorizontalAlignment="Center">🛑 Error 🛑</TextBlock>
                     <Separator/>
-                    <TextBlock Text="{Binding ErrorMessage}" HorizontalAlignment="Center"/>
+                    <SelectableTextBlock Text="{Binding ErrorMessage}" HorizontalAlignment="Center"/>
                     <Separator/>
                 </StackPanel>
             </Grid>


### PR DESCRIPTION
When a player exits the map the surroundings become empty. By showing an empty TileMap the screen flickers. Now the surroundings will be an fixed grid of Tile.Unknown the same size as the normal surroundings, so the UI stays the same size.

Furthermore, the seed is now shown in the game info block and the text is made selectable so it can be copied.