### PR TITLE
Add extra walls around exit when a door is placed

### DIFF
--- a/Infra/MapGenerator.cs
+++ b/Infra/MapGenerator.cs
@@ -1328,7 +1328,9 @@ internal class MapGeneratorImpl
         }
         // And walls for exit tunnel
         SetIfEmpty(exitPosition.y - 1, exitPosition.x - 1, Cell.Wall);
+        SetIfEmpty(exitPosition.y - 1, exitPosition.x, Cell.Wall);
         SetIfEmpty(exitPosition.y + 1, exitPosition.x - 1, Cell.Wall);
+        SetIfEmpty(exitPosition.y + 1, exitPosition.x, Cell.Wall);
 
         return (keyColor, doorPos);
     }

--- a/MapGeneratorTester/MainViewModel.cs
+++ b/MapGeneratorTester/MainViewModel.cs
@@ -1,4 +1,4 @@
-﻿using Swoq.Infra;
+using Swoq.Infra;
 using Swoq.InfraUI.ViewModels;
 using System.Windows.Input;
 
@@ -54,7 +54,7 @@ internal class MainViewModel : ViewModelBase, IDisposable
         }
     }
 
-    private int height = 38;
+    private int height = 48;
     public int Height
     {
         get => height;


### PR DESCRIPTION
This will make sure no open paths to the exit are possible when the exit is placed on a corner, like in level 2 with seed 335429528.

Fixes #107 